### PR TITLE
Ensure the ManageNSG rule is always removed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ jobs:
           rule-id-for-removal: ${{ steps.rule.outputs.rule_name }}
           rule-nsg-resource-group-name: ManageNsg
           rule-nsg-name: ManageNsg
-
+        if: always()
 ```
 
 ## Configure Azure credentials:


### PR DESCRIPTION
Just an update to your README for the suggested GitHub Action tasks.
Whatever happens in between Adding the NSG Rule and Removing the NSG rule may fail.  With this addition, any failed action will always remove the rule created regardless of the success of the steps before it. Without this, manual or automated CI/CD deployments or tests may result in hundreds of additional NSG rules added by ManageNSG if they happen to fail after the NSG rule addition but before the NSG rule removal.